### PR TITLE
Respect rate limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 dotenv = "0.15"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -20,3 +20,7 @@ rand = "0.8"
 webbrowser = "0.8.3"
 regex = "1"
 urlencoding = "2.1"
+reqwest-middleware = { version = "0.3.3", features = ["json"] }
+async-trait = "0.1.83"
+http = "1.1.0"
+anyhow = "1.0.89"

--- a/src/beyond_identity/admin.rs
+++ b/src/beyond_identity/admin.rs
@@ -5,7 +5,7 @@ use crate::beyond_identity::roles::{fetch_beyond_identity_roles, fetch_role_memb
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 
 pub async fn create_admin_account(
     client: &Client,

--- a/src/beyond_identity/api_token.rs
+++ b/src/beyond_identity/api_token.rs
@@ -1,7 +1,7 @@
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -101,7 +101,7 @@ pub async fn get_beyond_identity_api_token(
         application_id: tenant_config.application_id.clone(),
     };
     let serialized =
-        serde_json::to_string(&stored_token).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::to_string(&stored_token).map_err(BiError::SerdeError)?;
     fs::write(token_file_path.clone(), serialized)
         .map_err(|_| BiError::UnableToWriteFile(token_file_path))?;
 

--- a/src/beyond_identity/external_sso.rs
+++ b/src/beyond_identity/external_sso.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::api_token::get_beyond_identity_api_token;
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
@@ -184,7 +184,7 @@ pub async fn update_application_redirect_uri(
     application_id: &str,
     redirect_uri: &str,
 ) -> Result<(), BiError> {
-    let bi_api_token = get_beyond_identity_api_token(client, config, &tenant_config).await?;
+    let bi_api_token = get_beyond_identity_api_token(client, config, tenant_config).await?;
     let tenant_id = tenant_config.tenant_id.clone();
     let realm_id = tenant_config.realm_id.clone();
 
@@ -243,7 +243,7 @@ pub async fn load_external_sso(config: &Config) -> Result<ExternalSSO, BiError> 
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let external_sso_config: ExternalSSO =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(external_sso_config)
 }
 

--- a/src/beyond_identity/groups.rs
+++ b/src/beyond_identity/groups.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::api_token::get_beyond_identity_api_token;
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/beyond_identity/identities.rs
+++ b/src/beyond_identity/identities.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::api_token::get_beyond_identity_api_token;
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/beyond_identity/resource_servers.rs
+++ b/src/beyond_identity/resource_servers.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::api_token::get_beyond_identity_api_token;
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/beyond_identity/roles.rs
+++ b/src/beyond_identity/roles.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::api_token::get_beyond_identity_api_token;
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/beyond_identity/scim.rs
+++ b/src/beyond_identity/scim.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::api_token::get_beyond_identity_api_token;
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
@@ -208,7 +208,7 @@ async fn create_scim_app(
 ) -> Result<BeyondIdentityAppResponse, BiError> {
     let beyond_identity_api_base_url = config.beyond_identity_api_base_url.clone();
     let beyond_identity_api_token =
-        get_beyond_identity_api_token(&client, &config, &tenant_config).await?;
+        get_beyond_identity_api_token(client, config, tenant_config).await?;
     let tenant_id = tenant_config.tenant_id.clone();
     let realm_id = tenant_config.realm_id.clone();
 
@@ -339,7 +339,7 @@ pub async fn load_beyond_identity_scim_app(config: &Config) -> Result<BiScimConf
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let bi_scim_config: BiScimConfig =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(bi_scim_config)
 }
 

--- a/src/beyond_identity/sso_configs.rs
+++ b/src/beyond_identity/sso_configs.rs
@@ -4,7 +4,7 @@ use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
 use regex::Regex;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 

--- a/src/beyond_identity/tenant.rs
+++ b/src/beyond_identity/tenant.rs
@@ -1,7 +1,7 @@
 use crate::common::config::Config;
 use crate::common::error::BiError;
 use chrono::Utc;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{self, Write};
@@ -55,7 +55,7 @@ pub async fn load_tenant(config: &Config) -> Result<TenantConfig, BiError> {
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let tenant_config: TenantConfig =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(tenant_config)
 }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -79,16 +79,12 @@ impl Config {
 fn validate_env() -> Result<(), String> {
     let env_vars: HashMap<String, String> = env::vars().collect();
     let email_regex = Regex::new(r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$").unwrap();
-    let valid_api_urls = vec![
-        "https://api-us.beyondidentity.run",
+    let valid_api_urls = ["https://api-us.beyondidentity.run",
         "https://api-us.beyondidentity.xyz",
-        "https://api-us.beyondidentity.com",
-    ];
-    let valid_auth_urls = vec![
-        "https://auth-us.beyondidentity.run",
+        "https://api-us.beyondidentity.com"];
+    let valid_auth_urls = ["https://auth-us.beyondidentity.run",
         "https://auth-us.beyondidentity.xyz",
-        "https://auth-us.beyondidentity.com",
-    ];
+        "https://auth-us.beyondidentity.com"];
 
     // Validate OKTA_DOMAIN
     if let Some(okta_domain) = env_vars.get("OKTA_DOMAIN") {

--- a/src/common/error.rs
+++ b/src/common/error.rs
@@ -7,6 +7,8 @@ pub enum BiError {
     #[error(transparent)]
     ReqwestError(#[from] reqwest::Error),
     #[error(transparent)]
+    ReqwestMiddlewareError(#[from] reqwest_middleware::Error),
+    #[error(transparent)]
     SerdeError(#[from] serde_json::Error),
     #[error("{0}")]
     #[allow(dead_code)]

--- a/src/common/http.rs
+++ b/src/common/http.rs
@@ -1,0 +1,39 @@
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware, Error, Middleware, Next};
+
+struct RespectRateLimitMiddleware;
+
+#[async_trait::async_trait]
+impl Middleware for RespectRateLimitMiddleware {
+    async fn handle(
+        &self,
+        req: reqwest::Request,
+        ext: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> Result<reqwest::Response, Error> {
+        let duplicate_request = req.try_clone().ok_or_else(|| {
+            Error::Middleware(anyhow::anyhow!(
+                "Request object is not clonable. Are you passing a streaming body?".to_string()
+            ))
+        })?;
+
+        let response = next.clone().run(duplicate_request, ext).await?;
+
+        let status = response.status();
+        if let (reqwest::StatusCode::TOO_MANY_REQUESTS, Some(delay_secs)) =
+            (status, response.headers().get(reqwest::header::RETRY_AFTER))
+        {
+            if let Some(delay_secs) = delay_secs.to_str().ok().and_then(|ds| ds.parse().ok()) {
+                tokio::time::sleep(std::time::Duration::from_secs(delay_secs)).await;
+                return next.run(req, ext).await;
+            }
+        }
+
+        Ok(response)
+    }
+}
+
+pub fn new_http_client_for_api() -> ClientWithMiddleware {
+    ClientBuilder::new(reqwest::Client::new())
+        .with(RespectRateLimitMiddleware)
+        .build()
+}

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,2 +1,3 @@
 pub mod config;
 pub mod error;
+pub mod http;

--- a/src/okta/identity_provider.rs
+++ b/src/okta/identity_provider.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::external_sso::{update_application_redirect_uri, Exte
 use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
@@ -279,7 +279,7 @@ pub async fn load_okta_identity_provider(config: &Config) -> Result<OktaIdpRespo
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let okta_idp_response: OktaIdpResponse =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(okta_idp_response)
 }
 

--- a/src/okta/registration_attribute.rs
+++ b/src/okta/registration_attribute.rs
@@ -1,6 +1,6 @@
 use crate::common::config::Config;
 use crate::common::error::BiError;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
@@ -173,6 +173,6 @@ pub async fn load_custom_attribute(config: &Config) -> Result<OktaUserSchema, Bi
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let okta_user_schema: OktaUserSchema =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(okta_user_schema)
 }

--- a/src/okta/routing_rule.rs
+++ b/src/okta/routing_rule.rs
@@ -2,7 +2,7 @@ use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
 use crate::okta::identity_provider::OktaIdpResponse;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
@@ -199,6 +199,6 @@ pub async fn load_okta_routing_rule(config: &Config) -> Result<OktaRoutingRule, 
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let okta_routing_rule: OktaRoutingRule =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(okta_routing_rule)
 }

--- a/src/okta/scim.rs
+++ b/src/okta/scim.rs
@@ -1,7 +1,7 @@
 use crate::common::config::Config;
 use crate::common::error::BiError;
 use rand::Rng;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
@@ -529,7 +529,7 @@ pub async fn load_scim_app_in_okta(config: &Config) -> Result<OktaAppResponse, B
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let okta_app_response: OktaAppResponse =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(okta_app_response)
 }
 

--- a/src/onelogin/fast_migrate.rs
+++ b/src/onelogin/fast_migrate.rs
@@ -4,7 +4,7 @@ use crate::beyond_identity::tenant::TenantConfig;
 use crate::common::config::Config;
 use crate::common::error::BiError;
 use rand::Rng;
-use reqwest::Client;
+use reqwest_middleware::ClientWithMiddleware as Client;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::fs;
@@ -206,7 +206,7 @@ pub async fn load_onelogin_applications(
     let data = fs::read_to_string(&config_path)
         .map_err(|_| BiError::ConfigFileNotFound(config_path.clone()))?;
     let onelogin_applications: Vec<OneLoginApplication> =
-        serde_json::from_str(&data).map_err(|err| BiError::SerdeError(err))?;
+        serde_json::from_str(&data).map_err(BiError::SerdeError)?;
     Ok(onelogin_applications)
 }
 


### PR DESCRIPTION
This PR updates the script to respect HTTP 429 too many requests. 

Whenever HTTP 429 is received as a response, the script parses the `Retry-After` header to learn how long it needs to wait and retries the request after that number of seconds.

In many files, I needed this change in order to use ClientWithMiddleware instead of Client:

```diff
-- use reqwest::Client;
++ use reqwest_middleware::ClientWithMiddleware as Client;
```

The main change is in src/common/http.rs