### PR TITLE
docs: Add pathing information for local database instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,3 +157,24 @@ bi --version
 ## Usage
 
 For detailed usage instructions, see [Command Line Help](docs/CommandLineHelp.md).
+
+
+## Local Database Management
+
+`MacOs`
+
+```sh
+/Users/<localuser>/Library/Application Support/com.BeyondIdentity.bi
+```
+
+`Linux`
+
+```sh
+/home/<localuser>/.config/bi
+```
+
+`Windows`
+
+```sh
+C:\Users\<localuser>\AppData\Roaming\BeyondIdentity\bi
+```

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ For detailed usage instructions, see [Command Line Help](docs/CommandLineHelp.md
 
 
 ## Local Database Management
+The following are the locations of the local database
 
 `MacOs`
 


### PR DESCRIPTION
Adds information on where the local database is located Which was taken from the [ProjectDirs](https://yancouto.github.io/functional/directories/struct.ProjectDirs.html) crate.